### PR TITLE
feat: extend TrainingsManager with update, count, timestamps, and fix delete

### DIFF
--- a/src/trainings/ITrainingsManager.sol
+++ b/src/trainings/ITrainingsManager.sol
@@ -11,10 +11,12 @@ interface ITrainingsManager {
         bytes32 name; // unique name for the training of the owner
         bytes32 description;
         uint256 durationInMinutes;
+        uint256 createdAt;
     }
 
     event TrainingCreated(bytes32 name, address creator);
     event TrainingDeleted(bytes32 name, address creator);
+    event TrainingUpdated(bytes32 name, address creator);
 
     /// @notice Adds a new training for the calling user.
     /// @param trainingInfo The details of the training to be added.
@@ -30,4 +32,15 @@ interface ITrainingsManager {
     /// @notice Deletes a training by name.
     /// @param name The unique name of the training to be deleted.
     function deleteTraining(bytes32 name) external virtual;
+
+    /// @notice Updates a training's description and duration.
+    /// @param name The unique name of the training to update.
+    /// @param newDescription The new description.
+    /// @param newDurationInMinutes The new duration in minutes.
+    function updateTraining(bytes32 name, bytes32 newDescription, uint256 newDurationInMinutes) external virtual;
+
+    /// @notice Returns the number of trainings for a creator.
+    /// @param creator The address of the training creator.
+    /// @return The number of trainings.
+    function getTrainingCount(address creator) external view virtual returns (uint256);
 }

--- a/src/trainings/TrainingsManager.sol
+++ b/src/trainings/TrainingsManager.sol
@@ -26,7 +26,12 @@ contract TrainingsManager is ITrainingsManager {
             );
         }
 
-        trainings[creator].push(trainingInfo);
+        trainings[creator].push(TrainingInfo({
+            name: trainingInfo.name,
+            description: trainingInfo.description,
+            durationInMinutes: trainingInfo.durationInMinutes,
+            createdAt: block.timestamp
+        }));
 
         emit TrainingCreated(trainingInfo.name, msg.sender);
     }
@@ -39,15 +44,38 @@ contract TrainingsManager is ITrainingsManager {
 
     function deleteTraining(bytes32 name) external override {
         address creator = msg.sender;
+        uint256 len = trainings[creator].length;
+
+        for (uint256 i = 0; i < len; i++) {
+            if (trainings[creator][i].name == name) {
+                trainings[creator][i] = trainings[creator][len - 1];
+                trainings[creator].pop();
+
+                emit TrainingDeleted(name, msg.sender);
+                return;
+            }
+        }
+
+        revert("TrainingsManager: Training not found");
+    }
+
+    function updateTraining(bytes32 name, bytes32 newDescription, uint256 newDurationInMinutes) external override {
+        address creator = msg.sender;
 
         for (uint256 i = 0; i < trainings[creator].length; i++) {
             if (trainings[creator][i].name == name) {
-                delete trainings[creator][i];
+                trainings[creator][i].description = newDescription;
+                trainings[creator][i].durationInMinutes = newDurationInMinutes;
 
-                emit TrainingDeleted(name, msg.sender);
-
-                break;
+                emit TrainingUpdated(name, msg.sender);
+                return;
             }
         }
+
+        revert("TrainingsManager: Training not found");
+    }
+
+    function getTrainingCount(address creator) external view override returns (uint256) {
+        return trainings[creator].length;
     }
 }

--- a/test/TrainingsManager.t.sol
+++ b/test/TrainingsManager.t.sol
@@ -19,13 +19,15 @@ contract TrainingsManagerTest is Test {
             .TrainingInfo({
                 name: "Training 1",
                 description: "Description 1",
-                durationInMinutes: 60
+                durationInMinutes: 60,
+                createdAt: 0
             });
         ITrainingsManager.TrainingInfo memory trainingInfo2 = ITrainingsManager
             .TrainingInfo({
                 name: "Training 2",
                 description: "Description 2",
-                durationInMinutes: 120
+                durationInMinutes: 120,
+                createdAt: 0
             });
 
         vm.prank(trainingsCreator1);
@@ -56,6 +58,7 @@ contract TrainingsManagerTest is Test {
             trainings1[0].durationInMinutes,
             trainingInfo1.durationInMinutes
         );
+        assertGt(trainings1[0].createdAt, 0);
 
         ITrainingsManager.TrainingInfo[] memory trainings2 = trainingsManager
             .getTrainings(trainingsCreator2);
@@ -66,6 +69,7 @@ contract TrainingsManagerTest is Test {
             trainings2[0].durationInMinutes,
             trainingInfo2.durationInMinutes
         );
+        assertGt(trainings2[0].createdAt, 0);
     }
 
     function test_AddTrainingReverts() public {
@@ -73,13 +77,15 @@ contract TrainingsManagerTest is Test {
             .TrainingInfo({
                 name: "Training 1",
                 description: "Description 1",
-                durationInMinutes: 60
+                durationInMinutes: 60,
+                createdAt: 0
             });
         ITrainingsManager.TrainingInfo memory trainingInfo2 = ITrainingsManager
             .TrainingInfo({
                 name: "Training 1", // A user wants to create a training with already existing name
                 description: "Description 2",
-                durationInMinutes: 120
+                durationInMinutes: 120,
+                createdAt: 0
             });
 
         vm.startPrank(trainingsCreator1);
@@ -93,34 +99,119 @@ contract TrainingsManagerTest is Test {
     }
 
     function test_DeleteTraining() public {
-        ITrainingsManager.TrainingInfo memory trainingInfo = ITrainingsManager
+        ITrainingsManager.TrainingInfo memory t1 = ITrainingsManager
             .TrainingInfo({
                 name: "Training 1",
                 description: "Description 1",
-                durationInMinutes: 60
+                durationInMinutes: 60,
+                createdAt: 0
+            });
+        ITrainingsManager.TrainingInfo memory t2 = ITrainingsManager
+            .TrainingInfo({
+                name: "Training 2",
+                description: "Description 2",
+                durationInMinutes: 90,
+                createdAt: 0
+            });
+        ITrainingsManager.TrainingInfo memory t3 = ITrainingsManager
+            .TrainingInfo({
+                name: "Training 3",
+                description: "Description 3",
+                durationInMinutes: 120,
+                createdAt: 0
             });
 
-        vm.prank(trainingsCreator1);
-        trainingsManager.addTraining(trainingInfo);
+        vm.startPrank(trainingsCreator1);
+        trainingsManager.addTraining(t1);
+        trainingsManager.addTraining(t2);
+        trainingsManager.addTraining(t3);
 
-        ITrainingsManager.TrainingInfo[] memory trainings = trainingsManager
+        ITrainingsManager.TrainingInfo[] memory before = trainingsManager
             .getTrainings(trainingsCreator1);
-        assertEq(trainings.length, 1);
-        assertEq(trainings[0].name, trainingInfo.name);
-        assertEq(trainings[0].description, trainingInfo.description);
-        assertEq(
-            trainings[0].durationInMinutes,
-            trainingInfo.durationInMinutes
-        );
+        assertEq(before.length, 3);
 
+        // Delete the middle one (Training 2)
+        vm.expectEmit(true, true, false, true);
+        emit ITrainingsManager.TrainingDeleted(t2.name, trainingsCreator1);
+        trainingsManager.deleteTraining(t2.name);
+
+        ITrainingsManager.TrainingInfo[] memory after_ = trainingsManager
+            .getTrainings(trainingsCreator1);
+        assertEq(after_.length, 2);
+
+        // After swap-and-pop: Training 1 at [0], Training 3 moved to [1] (was swapped from last)
+        assertEq(after_[0].name, t1.name);
+        assertEq(after_[1].name, t3.name);
+
+        // Verify no zeroed-out slots
+        assertGt(after_[0].durationInMinutes, 0);
+        assertGt(after_[1].durationInMinutes, 0);
+
+        vm.stopPrank();
+    }
+
+    function test_DeleteTrainingReverts() public {
         vm.prank(trainingsCreator1);
+        vm.expectRevert("TrainingsManager: Training not found");
+        trainingsManager.deleteTraining("NonExistent");
+    }
+
+    function test_UpdateTraining() public {
+        ITrainingsManager.TrainingInfo memory t = ITrainingsManager
+            .TrainingInfo({
+                name: "Training 1",
+                description: "Old Description",
+                durationInMinutes: 60,
+                createdAt: 0
+            });
+
+        vm.startPrank(trainingsCreator1);
+        trainingsManager.addTraining(t);
+
+        ITrainingsManager.TrainingInfo[] memory before = trainingsManager
+            .getTrainings(trainingsCreator1);
+        uint256 originalCreatedAt = before[0].createdAt;
+        assertGt(originalCreatedAt, 0);
 
         vm.expectEmit(true, true, false, true);
-        emit ITrainingsManager.TrainingDeleted(
-            trainingInfo.name,
-            trainingsCreator1
-        );
+        emit ITrainingsManager.TrainingUpdated(t.name, trainingsCreator1);
+        trainingsManager.updateTraining(t.name, "New Description", 90);
 
-        trainingsManager.deleteTraining(trainingInfo.name);
+        ITrainingsManager.TrainingInfo[] memory after_ = trainingsManager
+            .getTrainings(trainingsCreator1);
+        assertEq(after_.length, 1);
+        assertEq(after_[0].name, t.name);
+        assertEq(after_[0].description, "New Description");
+        assertEq(after_[0].durationInMinutes, 90);
+        // createdAt should not change
+        assertEq(after_[0].createdAt, originalCreatedAt);
+
+        vm.stopPrank();
+    }
+
+    function test_UpdateTrainingReverts() public {
+        vm.prank(trainingsCreator1);
+        vm.expectRevert("TrainingsManager: Training not found");
+        trainingsManager.updateTraining("NonExistent", "Desc", 30);
+    }
+
+    function test_GetTrainingCount() public {
+        assertEq(trainingsManager.getTrainingCount(trainingsCreator1), 0);
+
+        ITrainingsManager.TrainingInfo memory t = ITrainingsManager
+            .TrainingInfo({
+                name: "Training 1",
+                description: "Description 1",
+                durationInMinutes: 60,
+                createdAt: 0
+            });
+
+        vm.startPrank(trainingsCreator1);
+        trainingsManager.addTraining(t);
+        assertEq(trainingsManager.getTrainingCount(trainingsCreator1), 1);
+
+        trainingsManager.deleteTraining(t.name);
+        assertEq(trainingsManager.getTrainingCount(trainingsCreator1), 0);
+        vm.stopPrank();
     }
 }


### PR DESCRIPTION
## Summary
- Add `createdAt` timestamp to `TrainingInfo` struct (set to `block.timestamp` on add)
- Add `updateTraining` function to modify description and duration, preserving createdAt
- Add `getTrainingCount` view function
- Fix `deleteTraining` to use swap-and-pop instead of `delete` (eliminates zeroed-out slots)
- Add revert on delete/update when training not found
- Add `TrainingUpdated` event
- Expand test suite to 7 tests (3 updated + 4 new)

## Test plan
- [x] `forge test -vvv` — all 7 tests pass
- [ ] Deploy to testnet and verify addTraining sets createdAt
- [ ] Verify deleteTraining swap-and-pop leaves no empty slots
- [ ] Verify updateTraining preserves createdAt